### PR TITLE
docs: Add StaticTableToolsTable docs

### DIFF
--- a/src/components/StaticTableToolsTable/StaticTableToolsTable.js
+++ b/src/components/StaticTableToolsTable/StaticTableToolsTable.js
@@ -20,13 +20,28 @@ import queryItems from './helpers/jsonQueryHelpers';
  *  @group Components
  *
  */
-const StaticTableToolsTable = ({ items, options, ...props }) => {
+const StaticTableToolsTable = ({
+  items,
+  options: { onSelect, enableExport, ...options } = {},
+  ...props
+}) => {
   const queriedItems = useCallback(
     async ({ filters, pagination, sort } = {}) =>
       await queryItems(items, {
         filters,
         ...pagination,
         sort,
+      }),
+    [items],
+  );
+
+  const queryAll = useCallback(
+    async ({ filters, sort } = {}) =>
+      await queryItems(items, {
+        filters,
+        sort,
+        offset: 0,
+        limit: 'max',
       }),
     [items],
   );
@@ -41,6 +56,19 @@ const StaticTableToolsTable = ({ items, options, ...props }) => {
           sort: sortSerialiser,
           filters: filtersSerialiser,
         },
+        ...(enableExport
+          ? {
+              exporter: async (serialisedTableState) =>
+                (await queryAll(serialisedTableState))[0],
+            }
+          : {}),
+        ...(onSelect
+          ? {
+              itemIdsInTable: async (serialisedTableState) =>
+                (await queryAll(serialisedTableState))[0].map(({ id }) => id),
+              onSelect,
+            }
+          : {}),
       }}
       {...props}
     />

--- a/src/components/StaticTableToolsTable/StaticTableToolsTable.js
+++ b/src/components/StaticTableToolsTable/StaticTableToolsTable.js
@@ -17,6 +17,8 @@ import queryItems from './helpers/jsonQueryHelpers';
  *
  *  @returns {React.ReactElement}                 Static table tools table
  *
+ *  @document ../../docs/using-static-tabletoolstable.md
+ *
  *  @group Components
  *
  */
@@ -50,7 +52,6 @@ const StaticTableToolsTable = ({
     <TableToolsTable
       items={queriedItems}
       options={{
-        ...options,
         serialisers: {
           pagination: paginationSerialiser,
           sort: sortSerialiser,
@@ -69,6 +70,7 @@ const StaticTableToolsTable = ({
               onSelect,
             }
           : {}),
+        ...options,
       }}
       {...props}
     />

--- a/src/components/StaticTableToolsTable/StaticTableToolsTable.stories.js
+++ b/src/components/StaticTableToolsTable/StaticTableToolsTable.stories.js
@@ -94,18 +94,15 @@ const StaticTableExample = ({
       options={{
         debug,
         manageColumns,
+        enableExport,
         ...(customEmptyRows ? { emptyRows: emptyRows(columns?.length) } : {}),
         ...(customEmptyState ? { EmptyState: CustomEmptyState } : {}),
-        ...(enableExport ? { exporter: () => arrayOfItems } : {}),
         ...(enableDetails ? { detailsComponent: DetailsRow } : {}),
         ...(enableBulkSelect
           ? {
               onSelect: (selected) => {
                 console.log('Currently selected', selected);
               },
-              // TODO verify these work when using an async function
-              itemIdsInTable: () => arrayOfItems.map(({ id }) => id),
-              itemIdsOnPage: () => arrayOfItems.map(({ id }) => id),
             }
           : {}),
       }}

--- a/src/docs/using-static-tabletoolstable.md
+++ b/src/docs/using-static-tabletoolstable.md
@@ -1,0 +1,221 @@
+---
+title: Using the StaticTableToolsTable component
+group: Documents
+category: Guides
+---
+
+# Using the StaticTableToolsTable component
+
+The `StaticTableToolsTable` component is a wrapper component around the `TableToolsTable`, which
+can handle "static" arrays of items and paginate them for cases where an API can not paginate or
+any other situation where it is not possible to dynamically get paginated items.
+
+A simple example of using the `StaticTableToolsTable` would look like this:
+
+```js
+import { StaticTableToolsTable } from 'bastilian-tabletools';
+
+const BasicStaticExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+    },
+    {
+      title: 'Artist',
+    },
+  ];
+
+  return (
+    <StaticTableToolsTable
+      items={arrayOfItems}
+      columns={columns}
+    />
+  );
+};
+
+export default BasicStaticExample;
+```
+
+The `StaticTableToolsTable` component also allows sorting and filtering via [jsonquery](https://jsonquerylang.org/).
+
+## Sorting the StaticTableToolsTable
+
+To enable sorting for any column, a `sortable` prop needs to be provided to identify the property the column should be sorted by.
+
+```js
+import { StaticTableToolsTable } from 'bastilian-tabletools';
+
+const BasicStaticSortedExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+      sortable: 'title',
+    },
+    {
+      title: 'Artist',
+      sortable: 'artist',
+    },
+  ];
+
+  return <StaticTableToolsTable items={arrayOfItems} columns={columns} />;
+};
+
+export default BasicStaticSortedExample;
+```
+
+## Filtering the StaticTableToolsTable
+
+Filters can be provided as with any other `TableToolsTable` based table and can have a `filterAttribute` to identify the property the items should be filtered by.
+For more complex filtering a `filterSerialiser` function can be passed, which should return a [jsonquery](https://jsonquerylang.org/) filter snippet as shown in the following example:
+
+```js
+import { StaticTableToolsTable } from 'bastilian-tabletools';
+
+const BasicStaticSortedFilteredExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+      sortable: 'title',
+      exportKey: 'title',
+    },
+    {
+      title: 'Artist',
+      sortable: 'artist',
+    },
+  ];
+
+  const filters = [
+    { type: 'text', label: 'Title', filterAttribute: 'title' },
+    { type: 'text', label: 'Artist', filterAttribute: 'artist' },
+    {
+      type: 'text',
+      label: 'Title or Artist',
+      filterSerialiser: (_config, [value]) =>
+        `regex(.artist, "${value}", "i") or regex(.title, "${value}", "i")`,
+    },
+  ];
+
+  return (
+    <StaticTableToolsTable
+      items={arrayOfItems}
+      columns={columns}
+      filters={{ filterConfig: filters }}
+    />
+  );
+};
+
+export default BasicStaticSortedFilteredExample;
+```
+
+## Bulk selecting a StaticTableToolsTable
+
+The `StaticTableToolsTable` component already provides necessary functions to make the correct selections
+and only requires being passed a `onSelect` function in the options to enable bulk selection.
+
+```js
+import { StaticTableToolsTable } from 'bastilian-tabletools';
+
+const BasicBulkSelectExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+      sortable: 'title',
+      exportKey: 'title',
+    },
+    {
+      title: 'Artist',
+      sortable: 'artist',
+    },
+  ];
+
+  const filters = [
+    { type: 'text', label: 'Title', filterAttribute: 'title' },
+    { type: 'text', label: 'Artist', filterAttribute: 'artist' },
+    {
+      type: 'text',
+      label: 'Title or Artist',
+      filterSerialiser: (_config, [value]) =>
+        `regex(.artist, "${value}", "i") or regex(.title, "${value}", "i")`,
+    },
+  ];
+
+  return (
+    <StaticTableToolsTable
+      items={arrayOfItems}
+      columns={columns}
+      filters={{ filterConfig: filters }}
+      options={{
+        onSelect: (currentSelection) => {
+          console.log('Currenlty selected', currentSelection);
+        },
+      }}
+    />
+  );
+};
+
+export default BasicBulkSelectExample;
+```
+
+## Exporting in a StaticTableToolsTable
+
+Enabling export in a StaticTableToolsTable is as simple as passing `enableExport` in the options:
+
+```js
+import { StaticTableToolsTable } from 'bastilian-tabletools';
+
+const BasicExportingExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+      sortable: 'title',
+      exportKey: 'title',
+    },
+    {
+      title: 'Artist',
+      sortable: 'artist',
+    },
+  ];
+
+  const filters = [
+    { type: 'text', label: 'Title', filterAttribute: 'title' },
+    { type: 'text', label: 'Artist', filterAttribute: 'artist' },
+    {
+      type: 'text',
+      label: 'Title or Artist',
+      filterSerialiser: (_config, [value]) =>
+        `regex(.artist, "${value}", "i") or regex(.title, "${value}", "i")`,
+    },
+  ];
+
+  return (
+    <StaticTableToolsTable
+      items={arrayOfItems}
+      columns={columns}
+      filters={{ filterConfig: filters }}
+      options={{
+        enableExport: true,
+        onSelect: (currentSelection) => {
+          console.log('Currenlty selected', currentSelection);
+        },
+      }}
+    />
+  );
+};
+
+export default BasicExportingExample;
+```

--- a/src/docs/using-static-tabletoolstable.stories.js
+++ b/src/docs/using-static-tabletoolstable.stories.js
@@ -1,0 +1,186 @@
+import React from 'react';
+
+import defaultStoryMeta from '~/support/defaultStoryMeta';
+import itemsFactory from '~/support/factories/items';
+
+import { StaticTableToolsTable } from '~/components';
+
+const meta = {
+  title: '"Using StaticTableToolsTable" tutorial examples',
+  ...defaultStoryMeta,
+};
+
+const BasicStaticExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+    },
+    {
+      title: 'Artist',
+    },
+  ];
+
+  return <StaticTableToolsTable items={arrayOfItems} columns={columns} />;
+};
+
+export const Basic = {
+  render: () => <BasicStaticExample />,
+};
+
+const BasicStaticSortedExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+      sortable: 'title',
+    },
+    {
+      title: 'Artist',
+      sortable: 'artist',
+    },
+  ];
+
+  return <StaticTableToolsTable items={arrayOfItems} columns={columns} />;
+};
+
+export const BasicSorted = {
+  render: () => <BasicStaticSortedExample />,
+};
+
+const BasicStaticSortedFilteredExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+      sortable: 'title',
+      exportKey: 'title',
+    },
+    {
+      title: 'Artist',
+      sortable: 'artist',
+    },
+  ];
+
+  const filters = [
+    { type: 'text', label: 'Title', filterAttribute: 'title' },
+    { type: 'text', label: 'Artist', filterAttribute: 'artist' },
+    {
+      type: 'text',
+      label: 'Title or Artist',
+      filterSerialiser: (_config, [value]) =>
+        `regex(.artist, "${value}", "i") or regex(.title, "${value}", "i")`,
+    },
+  ];
+
+  return (
+    <StaticTableToolsTable
+      items={arrayOfItems}
+      columns={columns}
+      filters={{ filterConfig: filters }}
+    />
+  );
+};
+
+export const BasicSortedFiltered = {
+  render: () => <BasicStaticSortedFilteredExample />,
+};
+
+const BasicBulkSelectExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+      sortable: 'title',
+      exportKey: 'title',
+    },
+    {
+      title: 'Artist',
+      sortable: 'artist',
+    },
+  ];
+
+  const filters = [
+    { type: 'text', label: 'Title', filterAttribute: 'title' },
+    { type: 'text', label: 'Artist', filterAttribute: 'artist' },
+    {
+      type: 'text',
+      label: 'Title or Artist',
+      filterSerialiser: (_config, [value]) =>
+        `regex(.artist, "${value}", "i") or regex(.title, "${value}", "i")`,
+    },
+  ];
+
+  return (
+    <StaticTableToolsTable
+      items={arrayOfItems}
+      columns={columns}
+      filters={{ filterConfig: filters }}
+      options={{
+        onSelect: (currentSelection) => {
+          console.log('Currenlty selected', currentSelection);
+        },
+      }}
+    />
+  );
+};
+
+export const BasicBulkSelect = {
+  render: () => <BasicBulkSelectExample />,
+};
+
+const BasicExportingExample = () => {
+  const arrayOfItems = itemsFactory(4096);
+
+  const columns = [
+    {
+      title: 'Title',
+      key: 'title',
+      sortable: 'title',
+      exportKey: 'title',
+    },
+    {
+      title: 'Artist',
+      sortable: 'artist',
+    },
+  ];
+
+  const filters = [
+    { type: 'text', label: 'Title', filterAttribute: 'title' },
+    { type: 'text', label: 'Artist', filterAttribute: 'artist' },
+    {
+      type: 'text',
+      label: 'Title or Artist',
+      filterSerialiser: (_config, [value]) =>
+        `regex(.artist, "${value}", "i") or regex(.title, "${value}", "i")`,
+    },
+  ];
+
+  return (
+    <StaticTableToolsTable
+      items={arrayOfItems}
+      columns={columns}
+      filters={{ filterConfig: filters }}
+      options={{
+        enableExport: true,
+        onSelect: (currentSelection) => {
+          console.log('Currenlty selected', currentSelection);
+        },
+      }}
+    />
+  );
+};
+
+export const BasicExport = {
+  render: () => <BasicExportingExample />,
+};
+
+export default meta;

--- a/src/docs/using-table-tools.md
+++ b/src/docs/using-table-tools.md
@@ -1,5 +1,5 @@
 ---
-title: Using the table tools
+title: Using the TableToolsTable component
 group: Documents
 category: Guides
 ---

--- a/src/docs/using-table-tools.md
+++ b/src/docs/using-table-tools.md
@@ -41,7 +41,6 @@ We also provide an async "`fetchItems`" function, which will be called by the `T
 should return the items to show in the table for the current page and
 the overall total number of items that are available to browse.
 
-Providing an async function as for the `items` prop is one way to use the `TableToolsTable`.
 Another way is by passing an array as the `items`, as well as the `total` and `loading` as a prop,
 if you are using a `useQuery`(-like) hook like in the following example:
 
@@ -96,6 +95,7 @@ const BasicStateExample = () => {
     { pagination: { state: pagination } = {} } = {},
   ) => {
     const params = new URLSearchParams(
+      // returns {limit: XXX, offset: XXX}
       convertToOffsetAndLimit(pagination),
     ).toString();
     const response = await fetch('/api?' + params);
@@ -117,8 +117,11 @@ const BasicStateExample = () => {
 export default BasicStateExample;
 ```
 
-The **first** parameter passed to the function is the __serialisedState_. The serialised state is used
-when a "serialiser" is provided, which is a function that converts a table state into any wanted format when the state is changed.
+## Serialising the table state
+
+The **first** parameter passed to the function is the *_serialisedTableState*.
+This a "serialised" representation of the tables' state and is used when a "serialiser" is provided,
+which is a function that converts a table state into any wanted format when the state is changed.
 
 We can for example provide the `convertToOffsetAndLimit` function as a serialiser for the pagination state:
 
@@ -156,6 +159,8 @@ const BasicSerialisedStateExample = () => {
 
 export default BasicSerialisedStateExample;
 ```
+
+## Accessing the state via context
 
 In cases where the `TableToolsTable` is used with a query hook or similar,
 the table state can be accessed via a hook to access the table context.
@@ -214,4 +219,4 @@ export default BasicQueryWithSerialisedStateExampleWrapper;
 
 With this you should be able to build a basic paginated table for any API resource.
 The `TableToolsTable` also allows adding filters, enable sorting, enhance columns and
-many other features covered in other parts of the/future documentation.
+many other features covered in other parts of the documentation.

--- a/src/docs/using-table-tools.stories.js
+++ b/src/docs/using-table-tools.stories.js
@@ -71,6 +71,7 @@ const BasicStateExample = () => {
     { pagination: { state: pagination } = {} } = {},
   ) => {
     const params = new URLSearchParams(
+      // returns {limit: XXX, offset: XXX}
       convertToOffsetAndLimit(pagination),
     ).toString();
     const response = await fetch('/api?' + params);

--- a/src/hooks/useBulkSelect/useBulkSelect.js
+++ b/src/hooks/useBulkSelect/useBulkSelect.js
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useDeepCompareEffect } from 'use-deep-compare';
 
+import { useFullTableState } from '~/hooks';
 import useSelectionManager from '~/hooks/useSelectionManager';
 import useCallbacksCallback from '~/hooks/useTableState/hooks/useCallbacksCallback';
 
@@ -64,6 +65,7 @@ const useBulkSelect = ({
     itemIdsOnPage,
     selectedIds,
   );
+  const { tableState, serialisedTableState } = useFullTableState() || {};
 
   // TODO this is not totally wrong, but when the tree view is active there is currently no total, which causes the selection to be disabled there.
   // The bug may not even be fixed here, but in the tables that use selection and the tree view. They will need to provide an appropriate total still
@@ -97,15 +99,22 @@ const useBulkSelect = ({
 
   useCallbacksCallback('resetSelection', resetSelection);
 
-  const selectAll = async () => {
+  const selectAll = useCallback(async () => {
     setLoading(true);
     if (allSelected) {
       clear();
     } else {
-      set(await itemIdsInTable());
+      set(await itemIdsInTable(serialisedTableState, tableState));
     }
     setLoading(false);
-  };
+  }, [
+    allSelected,
+    clear,
+    set,
+    itemIdsInTable,
+    tableState,
+    serialisedTableState,
+  ]);
 
   const markRowSelected = useCallback(
     (item, rowsForItem, _runningIndex, isTreeTable) => {

--- a/src/hooks/useExport/useExport.js
+++ b/src/hooks/useExport/useExport.js
@@ -1,5 +1,7 @@
 import { useCallback } from 'react';
 
+import { useFullTableState } from '~/hooks';
+
 import { downloadItems, exportableColumns } from './helpers';
 
 /**
@@ -35,12 +37,14 @@ const useExport = ({
 }) => {
   const enableExport = !!exporter;
   const exportColumns = exportableColumns(columns);
+  const { tableState, serialisedTableState } = useFullTableState() || {};
+
   const exportWithFormat = useCallback(
     async (format) => {
       onStart?.();
 
       try {
-        const items = await exporter();
+        const items = await exporter(serialisedTableState, tableState);
 
         downloadItems(exportColumns, items, format);
         onComplete?.(items);
@@ -49,7 +53,15 @@ const useExport = ({
         onError?.(error);
       }
     },
-    [onStart, onError, onComplete, exporter, exportColumns],
+    [
+      onStart,
+      onError,
+      onComplete,
+      exporter,
+      exportColumns,
+      tableState,
+      serialisedTableState,
+    ],
   );
 
   return enableExport


### PR DESCRIPTION
This PR implements features to enable export and bulk selecting out of the box for the `StaticTableToolsTable` component. 

The export can be enabled by passing `enableExport: true` as an option to the `StaticTableToolsTable` component. 
The bulk selection will be enabled when a `onSelect` function is passed as an option.

New documentation and stories have been added for basic usage of the component as well as documentation on how to enable both new features.


**How to test:**

1) `npm run storybook`
2) Test the stories for the `StaticTableToolsTable` component as well as stories of the tutorial

