### PR TITLE
fix: Reintroduce selected items in tableState

### DIFF
--- a/src/hooks/useBulkSelect/useBulkSelect.js
+++ b/src/hooks/useBulkSelect/useBulkSelect.js
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useDeepCompareEffect } from 'use-deep-compare';
 
-import { useFullTableState } from '~/hooks';
+import useTableState, { useFullTableState } from '~/hooks/useTableState';
 import useSelectionManager from '~/hooks/useSelectionManager';
 import useCallbacksCallback from '~/hooks/useTableState/hooks/useCallbacksCallback';
 
@@ -66,6 +66,7 @@ const useBulkSelect = ({
     selectedIds,
   );
   const { tableState, serialisedTableState } = useFullTableState() || {};
+  const [, setSelected] = useTableState('selected');
 
   // TODO this is not totally wrong, but when the tree view is active there is currently no total, which causes the selection to be disabled there.
   // The bug may not even be fixed here, but in the tables that use selection and the tree view. They will need to provide an appropriate total still
@@ -139,6 +140,10 @@ const useBulkSelect = ({
     },
     [selectedIds],
   );
+
+  useDeepCompareEffect(() => {
+    setSelected(selectedIds);
+  }, [selectedIds, setSelected]);
 
   useDeepCompareEffect(() => {
     if (selected) {

--- a/src/hooks/useBulkSelect/useBulkSelect.test.js
+++ b/src/hooks/useBulkSelect/useBulkSelect.test.js
@@ -1,4 +1,5 @@
 import { renderHook } from '@testing-library/react';
+import { DEFAULT_RENDER_OPTIONS } from '~/support/testHelpers';
 
 import useBulkSelect from './useBulkSelect';
 
@@ -18,50 +19,59 @@ describe('useBulkSelect', () => {
   };
 
   it('returns a bulk select configuration', () => {
-    const { result } = renderHook(() => useBulkSelect(defaultOptions));
+    const { result } = renderHook(
+      () => useBulkSelect(defaultOptions),
+      DEFAULT_RENDER_OPTIONS,
+    );
 
     expect(result).toMatchSnapshot();
   });
 
   it('returns a bulk select configuration without select all', () => {
-    const { result } = renderHook(() =>
-      useBulkSelect({
-        ...defaultOptions,
-        total: 2,
-        preselected: ['ID'],
-        itemIdsInTable: () => {
-          return ['ID', 'ID1'];
-        },
-        itemIdsOnPage: ['ID', 'ID1'],
-      }),
+    const { result } = renderHook(
+      () =>
+        useBulkSelect({
+          ...defaultOptions,
+          total: 2,
+          preselected: ['ID'],
+          itemIdsInTable: () => {
+            return ['ID', 'ID1'];
+          },
+          itemIdsOnPage: ['ID', 'ID1'],
+        }),
+      DEFAULT_RENDER_OPTIONS,
     );
 
     expect(result.current.toolbarProps.bulkSelect.items).toMatchSnapshot();
   });
 
   it('returns a bulk select configuration with select all', () => {
-    const { result } = renderHook(() =>
-      useBulkSelect({
-        ...defaultOptions,
-        total: 2,
-        preselected: ['ID'],
-        fetchAll: Promise.resolve(['2417de', '51b20a']),
-        itemIdsOnPage: ['ID', 'ID1'],
-      }),
+    const { result } = renderHook(
+      () =>
+        useBulkSelect({
+          ...defaultOptions,
+          total: 2,
+          preselected: ['ID'],
+          fetchAll: Promise.resolve(['2417de', '51b20a']),
+          itemIdsOnPage: ['ID', 'ID1'],
+        }),
+      DEFAULT_RENDER_OPTIONS,
     );
 
     expect(result.current.toolbarProps.bulkSelect.items).toMatchSnapshot();
   });
 
   it('returns a bulk select configuration with 1 selected item', () => {
-    const { result } = renderHook(() =>
-      useBulkSelect({
-        ...defaultOptions,
-        total: 2,
-        preselected: ['ID'],
-        itemIdsInTable: () => ['ID', 'ID2'],
-        itemIdsOnPage: ['ID'],
-      }),
+    const { result } = renderHook(
+      () =>
+        useBulkSelect({
+          ...defaultOptions,
+          total: 2,
+          preselected: ['ID'],
+          itemIdsInTable: () => ['ID', 'ID2'],
+          itemIdsOnPage: ['ID'],
+        }),
+      DEFAULT_RENDER_OPTIONS,
     );
 
     expect(result.current.toolbarProps.bulkSelect.count).toEqual(1);

--- a/src/hooks/useDebug.js
+++ b/src/hooks/useDebug.js
@@ -2,7 +2,7 @@ import { useContext, useEffect } from 'react';
 import { TableContext } from './useTableState/constants';
 
 const useDebug = (debugProp) => {
-  const { debug: contextDebug } = useContext(TableContext);
+  const { debug: contextDebug } = useContext(TableContext) || {};
 
   useEffect(() => {
     if (debugProp) {
@@ -11,7 +11,7 @@ const useDebug = (debugProp) => {
     }
   }, [debugProp, contextDebug]);
 
-  return contextDebug.current;
+  return contextDebug?.current || false;
 };
 
 export default useDebug;


### PR DESCRIPTION
This reintroduces the `selected` state into the table state to make it accessible again via the table context and the state hooks.

**How to test:**

1) Run & open Storybook with `npm run storybook`
2) Test selection in any story that has bulk selection enabled
3) Verify (via debug/console output) that the `selected` state is set and present when the selection changed