### PR TITLE
refactor: remove all references to renderFunc in favor of key/Compone…

### DIFF
--- a/src/components/TableToolsTable/TableToolsTable.js
+++ b/src/components/TableToolsTable/TableToolsTable.js
@@ -112,7 +112,7 @@ TableToolsTable.propTypes = {
       sortByProperty: propTypes.string,
       sortByArray: propTypes.array,
       sortByFunction: propTypes.func,
-      renderFunc: propTypes.func,
+      
     }),
   ).isRequired,
   filters: propTypes.object,

--- a/src/components/TableToolsTable/TableToolsTable.js
+++ b/src/components/TableToolsTable/TableToolsTable.js
@@ -112,7 +112,6 @@ TableToolsTable.propTypes = {
       sortByProperty: propTypes.string,
       sortByArray: propTypes.array,
       sortByFunction: propTypes.func,
-      
     }),
   ).isRequired,
   filters: propTypes.object,

--- a/src/components/TableToolsTable/TableToolsTable.test.js
+++ b/src/components/TableToolsTable/TableToolsTable.test.js
@@ -18,7 +18,7 @@ describe('TableToolsTable', () => {
       {
         title: 'Title',
         key: 'title',
-        renderFunc: (_a, _b, item) => item.title,
+
       },
     ],
     items: itemsFunc,

--- a/src/components/TableToolsTable/TableToolsTable.test.js
+++ b/src/components/TableToolsTable/TableToolsTable.test.js
@@ -18,7 +18,6 @@ describe('TableToolsTable', () => {
       {
         title: 'Title',
         key: 'title',
-
       },
     ],
     items: itemsFunc,

--- a/src/hooks/useTableView/views/helpers.js
+++ b/src/hooks/useTableView/views/helpers.js
@@ -12,7 +12,7 @@ const renderCell = (column, item) => {
     // NOTE: When using "deep compare" effects that have the rows
     // or the object containing rows as dependencies will raise a "too much recursion" error (via dequal)
     return <Component {...item} />;
-  }  else {
+  } else {
     return item[columnProp(column)];
   }
 };
@@ -119,7 +119,6 @@ export const getOnTreeSelect = (options) => {
 export const treeTableGroupColumns = [
   {
     key: 'title',
-    
   },
 ];
 

--- a/src/hooks/useTableView/views/helpers.js
+++ b/src/hooks/useTableView/views/helpers.js
@@ -6,16 +6,13 @@ const columnProp = (column) =>
   column.key || column.original?.toLowerCase() || column.title?.toLowerCase();
 
 const renderCell = (column, item) => {
-  const { Component, renderFunc } = column;
+  const { Component } = column;
 
   if (Component) {
     // NOTE: When using "deep compare" effects that have the rows
     // or the object containing rows as dependencies will raise a "too much recursion" error (via dequal)
     return <Component {...item} />;
-  } else if (renderFunc) {
-    // TODO deprecated "rednerFunc"
-    return renderFunc(undefined, undefined, item);
-  } else {
+  }  else {
     return item[columnProp(column)];
   }
 };
@@ -122,7 +119,7 @@ export const getOnTreeSelect = (options) => {
 export const treeTableGroupColumns = [
   {
     key: 'title',
-    renderFunc: (_u, _n, item) => <strong>{item.title}</strong>,
+    
   },
 ];
 

--- a/src/hooks/useTableView/views/treeChopper.test.js
+++ b/src/hooks/useTableView/views/treeChopper.test.js
@@ -5,11 +5,11 @@ import treeChopper from './treeChopper';
 const columns = [
   {
     title: 'Name',
-    key:'name',
+    key: 'name',
   },
   {
     title: 'Description',
-    key:"description",
+    key: 'description',
   },
 ];
 

--- a/src/hooks/useTableView/views/treeChopper.test.js
+++ b/src/hooks/useTableView/views/treeChopper.test.js
@@ -5,11 +5,11 @@ import treeChopper from './treeChopper';
 const columns = [
   {
     title: 'Name',
-    renderFunc: (_a, _b, { name }) => name,
+    key:'name',
   },
   {
     title: 'Description',
-    renderFunc: (_a, _b, { description }) => description,
+    key:"description",
   },
 ];
 


### PR DESCRIPTION
## Remove all references to `renderFunc` in favor of `key`/`Component` props

This PR addresses [Issue #49](https://github.com/bastilian/tabletools/issues/49).

### Summary

- **Removed** all usages and references to the deprecated `renderFunc` property in column definitions, helpers, and tests.
- **Replaced** with the `key` prop for simple value rendering and the `Component` prop for custom cell rendering.
- **Updated** propTypes and documentation to reflect these changes.
- **Refactored** tests and helper utilities to ensure compatibility with the new approach.



### Checklist

- [x] All references to `renderFunc` removed
- [x] Columns use `key` or `Component` as appropriate
- [x] Tests updated and passing
---

Closes #49