### PR TITLE
refactor(useColumnManager): Use title as identifier for selected columns

### DIFF
--- a/src/hooks/useColumnManager/helper.js
+++ b/src/hooks/useColumnManager/helper.js
@@ -1,8 +1,14 @@
-export const getFixedColumns = (columns = []) =>
-  columns.map((column, idx) => ({
-    manageable: column.manageable === undefined ? true : column.manageable,
-    isUntoggleable: idx === 0,
-    isShownByDefault: true,
-    isShown: true,
-    ...column,
-  }));
+export const getColumnsForModal = (columns = [], selectedColumns) =>
+  columns.map(({ title, manageable, isShown: isShownProp }) => {
+    const isShown = selectedColumns?.includes(title) || isShownProp;
+    const isUntoggleable =
+      typeof manageable !== 'undefined' ? !manageable : false;
+
+    return {
+      title,
+      key: title,
+      isUntoggleable,
+      isShownByDefault: isShown,
+      isShown,
+    };
+  });

--- a/src/support/factories/columns.js
+++ b/src/support/factories/columns.js
@@ -17,6 +17,7 @@ export const title = {
   Component: Title,
   renderExport: ({ title }) => title,
   sortable: 'title',
+  manageable: false,
 };
 
 export const artist = {


### PR DESCRIPTION
This cleans up the column manager hook and changes to only keeping the title as an identifier in the state.