### PR TITLE
docs(TableToolsTable): Fix artists by genre filter

### DIFF
--- a/src/components/FilterModal/FilterModal.test.js
+++ b/src/components/FilterModal/FilterModal.test.js
@@ -16,7 +16,6 @@ describe('FilterModal', () => {
 
   describe('with group filter', function () {
     it('expect to render without error', async () => {
-      console.log('artistByGenre', artistByGenre, artistByGenre.items[0]);
       render(
         <FilterModal
           filter={artistByGenre}

--- a/src/support/factories/filters.js
+++ b/src/support/factories/filters.js
@@ -68,12 +68,17 @@ const artistsGroupedByGenre = Object.groupBy(items, ({ genre }) => genre);
 export const artistByGenre = {
   type: 'group',
   label: 'Artist by genre',
-  items: Object.entries(artistsGroupedByGenre).map(([genre, artists]) => ({
+  filterSerialiser: (_filterConfigItem, value) =>
+    `.artist in [${Object.entries(value)
+      .reduce((_genre, [, artists]) => [...Object.keys(artists)], [])
+      .map((artist) => `"${artist}"`)
+      .join(', ')}]`,
+  groups: Object.entries(artistsGroupedByGenre).map(([genre, artists]) => ({
     label: genre,
     value: genre,
-    items: artists.slice(0, 10).map(({ id, artist }) => ({
+    items: artists.slice(0, 10).map(({ artist }) => ({
       label: artist,
-      value: id,
+      value: artist,
     })),
   })),
   modal: true,


### PR DESCRIPTION
The artist by genre group filter was misconfigured and didn't provide "groups", but "items".