### PR TITLE
feat(TableStateProvider): Only create a new context if none exists

### DIFF
--- a/src/components/TableStateProvider/TableStateProvider.js
+++ b/src/components/TableStateProvider/TableStateProvider.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useContext, useState, useRef } from 'react';
 import propTypes from 'prop-types';
 
 import { TableContext } from '~/hooks/useTableState/constants';
@@ -42,4 +42,15 @@ TableStateProvider.propTypes = {
   children: propTypes.node,
 };
 
-export default TableStateProvider;
+const TableStateProviderWrapper = ({ children }) => {
+  const tableContext = useContext(TableContext);
+  const Wrapper = tableContext ? React.Fragment : TableStateProvider;
+
+  return <Wrapper>{children}</Wrapper>;
+};
+
+TableStateProviderWrapper.propTypes = {
+  children: propTypes.node,
+};
+
+export default TableStateProviderWrapper;

--- a/src/components/TableToolsTable/TableToolsTable.js
+++ b/src/components/TableToolsTable/TableToolsTable.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import propTypes from 'prop-types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
@@ -150,17 +150,12 @@ TableToolsTable.propTypes = {
  *  @group Components
  *
  */
-const TableToolsTableWithOrWithoutProvider = (props) => {
-  const tableContext = useContext(TableContext);
-  const Wrapper = tableContext ? React.Fragment : TableStateProvider;
-
-  return (
-    <QueryClientProvider client={queryClient}>
-      <Wrapper>
-        <TableToolsTable {...props} />
-      </Wrapper>
-    </QueryClientProvider>
-  );
-};
+const TableToolsTableWithOrWithoutProvider = (props) => (
+  <QueryClientProvider client={queryClient}>
+    <TableStateProvider>
+      <TableToolsTable {...props} />
+    </TableStateProvider>
+  </QueryClientProvider>
+);
 
 export default TableToolsTableWithOrWithoutProvider;

--- a/src/components/TableToolsTable/TableToolsTableExperiments.stories.js
+++ b/src/components/TableToolsTable/TableToolsTableExperiments.stories.js
@@ -1,0 +1,89 @@
+import React, { useEffect } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import defaultStoryMeta from '~/support/defaultStoryMeta';
+import columns from '~/support/factories/columns';
+import paginationSerialiser from '~/components/StaticTableToolsTable/helpers/serialisers/pagination';
+import sortSerialiser from '~/components/StaticTableToolsTable/helpers/serialisers/sort';
+import filtersSerialiser from '~/components/StaticTableToolsTable/helpers/serialisers/filters';
+import useExampleDataQuery from '~/support/hooks/useExampleDataQuery';
+
+import { TableToolsTable, TableStateProvider } from '~/components';
+import { useFullTableState } from '~/hooks';
+
+const queryClient = new QueryClient();
+
+const defaultOptions = {
+  serialisers: {
+    pagination: paginationSerialiser,
+    sort: sortSerialiser,
+    filters: filtersSerialiser,
+  },
+};
+
+const meta = {
+  title: 'TableToolsTable Experiments',
+  ...defaultStoryMeta,
+};
+
+const ContextExample = () => {
+  const {
+    loading,
+    result: { data, meta: { total } = {} } = {},
+    error,
+  } = useExampleDataQuery({ endpoint: '/api', useTableState: true });
+
+  return (
+    <TableToolsTable
+      loading={loading}
+      items={data}
+      total={total}
+      error={error}
+      columns={columns}
+      options={defaultOptions}
+    />
+  );
+};
+
+const ContextExampleWrapper = () => {
+  return (
+    <TableStateProvider>
+      <ContextExample />
+    </TableStateProvider>
+  );
+};
+
+const ContextExampleSecondWrapper = () => {
+  const fullTableState = useFullTableState();
+
+  useEffect(() => {
+    console.log(
+      'Even though there are multiple TableStateProviders in between the highest should always be the one with access',
+      fullTableState,
+    );
+  }, [fullTableState]);
+
+  return (
+    <TableStateProvider>
+      <ContextExampleWrapper />
+    </TableStateProvider>
+  );
+};
+
+// This story is to test that it is possible to "raise" the context
+// The TableStateProvider is implemented to only insert itself into the stack if there is not already a tablecontext available.
+// The TableStateProvider in here is still the primary one accessed in ContextExampleSecondWrapper
+export const ContextStory = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TableStateProvider>
+          <Story />
+        </TableStateProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  render: (args) => <ContextExampleSecondWrapper {...args} />,
+};
+
+export default meta;


### PR DESCRIPTION
This addresses #62 and changes the `TableStateProvider` to only insert itself and create a new context if there isn't one already. 

This allows shared tables based on `TableToolsTables` to "raise" the context and make it possible to access the context higher up.

There are now also "experiments stories" the first experiment being a table with multiple providers in between it and where the context is accessed to test this feature. 