### PR TITLE
feat: Implement more external controls

### DIFF
--- a/src/hooks/useFilterConfig/helpers/filterTypeHelpers/index.js
+++ b/src/hooks/useFilterConfig/helpers/filterTypeHelpers/index.js
@@ -4,7 +4,6 @@ import textType from './textType';
 import checkboxType from './checkboxType';
 import radioType from './radioType';
 import groupType from './groupType';
-export { default as customType } from './customType';
 
 export default {
   [conditionalFilterType.text]: textType,

--- a/src/hooks/useFilterConfig/helpers/helpers.js
+++ b/src/hooks/useFilterConfig/helpers/helpers.js
@@ -1,6 +1,6 @@
 import isArray from 'lodash/isEmpty';
 import isObject from 'lodash/isObject';
-import { customType as defaultCustomTypeHelper } from './filterTypeHelpers';
+import defaultCustomTypeHelper from './filterTypeHelpers/customType';
 
 export const stringToId = (string) =>
   string.split(/\s+/).join('-').toLowerCase();

--- a/src/hooks/useFilterConfig/useFilterConfig.js
+++ b/src/hooks/useFilterConfig/useFilterConfig.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { useDebouncedCallback } from '@tanstack/react-pacer/debouncer';
 
 import useSelectionManager from '~/hooks/useSelectionManager';
@@ -87,7 +87,15 @@ const useFilterConfig = (options) => {
     debouncedSetState(activeFilters);
   }, [activeFilters, debouncedSetState]);
 
+  const setFilter = useCallback(
+    (filter, value) => {
+      selectionActions.set(value, filter);
+    },
+    [selectionActions],
+  );
+
   useCallbacksCallback('clearFilters', selectionActions.clear);
+  useCallbacksCallback('setFilter', setFilter);
 
   return enableFilters
     ? {

--- a/src/hooks/useFilterConfig/useFilterConfig.stories.js
+++ b/src/hooks/useFilterConfig/useFilterConfig.stories.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Button, Card, CardBody, Content } from '@patternfly/react-core';
 
 import defaultStoryMeta from '~/support/defaultStoryMeta';
 import columns from '~/support/factories/columns';
-import {
+import filters, {
   customNumberFilter,
   customNumberFilterType,
   customGenresFilter,
@@ -16,10 +17,12 @@ import filtersSerialiser from '~/components/StaticTableToolsTable/helpers/serial
 import useExampleDataQuery from '~/support/hooks/useExampleDataQuery';
 
 import { TableToolsTable, TableStateProvider } from '~/components';
+import { useStateCallbacks } from '~/hooks';
 
 const queryClient = new QueryClient();
 
 const defaultOptions = {
+  debug: true,
   serialisers: {
     pagination: paginationSerialiser,
     sort: sortSerialiser,
@@ -84,6 +87,100 @@ export const CustomFiltersStory = {
     ),
   ],
   render: (args) => <CustomFiltersExample {...args} />,
+};
+
+const SetFilterExample = () => {
+  const {
+    current: { setFilter },
+  } = useStateCallbacks();
+  const {
+    loading,
+    result: { data, meta: { total } = {} } = {},
+    error,
+  } = useExampleDataQuery({
+    endpoint: '/api',
+    useTableState: true,
+  });
+
+  return (
+    <>
+      <Content>
+        <p>This story is to test the `setFilter`</p>
+      </Content>
+      <Card>
+        <CardBody>
+          <Button
+            onClick={() => {
+              setFilter('rating-above', [1]);
+            }}
+          >
+            1
+          </Button>
+          <Button
+            onClick={() => {
+              setFilter('rating-above', [2]);
+            }}
+          >
+            2
+          </Button>
+          <Button
+            onClick={() => {
+              setFilter('rating-above', [3]);
+            }}
+          >
+            3
+          </Button>
+          <Button
+            onClick={() => {
+              setFilter('rating-above', [4]);
+            }}
+          >
+            4
+          </Button>
+          <Button
+            onClick={() => {
+              setFilter('rating-above', [5]);
+            }}
+          >
+            5
+          </Button>
+          <Button
+            onClick={() => {
+              setFilter('title', ['ghost']);
+            }}
+          >
+            Set title filter to "ghost"
+          </Button>
+        </CardBody>
+      </Card>
+      <TableToolsTable
+        loading={loading}
+        items={data}
+        total={total}
+        error={error}
+        columns={columns}
+        filters={{
+          filterConfig: filters,
+        }}
+        options={{
+          ...defaultOptions,
+        }}
+      />
+    </>
+  );
+};
+
+export const SetFilterStory = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TableStateProvider>
+          <Story />
+        </TableStateProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  render: (args) => <SetFilterExample {...args} />,
 };
 
 export default meta;

--- a/src/hooks/useFilterConfig/useFilterConfig.stories.js
+++ b/src/hooks/useFilterConfig/useFilterConfig.stories.js
@@ -149,7 +149,7 @@ const SetFilterExample = () => {
               setFilter('title', ['ghost']);
             }}
           >
-            Set title filter to "ghost"
+            Set title filter to &quot;ghost&quot;
           </Button>
         </CardBody>
       </Card>

--- a/src/hooks/useItems/useItems.js
+++ b/src/hooks/useItems/useItems.js
@@ -28,7 +28,7 @@ const useItems = (
   externalItems,
   externalError,
   externalTotal,
-  { itemsOptions: { queryKey } = {} },
+  { itemsOptions: { queryKey } = {} } = {},
 ) => {
   const tableState = useRawTableState();
   const { filter, sort, pagination } = tableState || {};

--- a/src/hooks/useItems/useItems.js
+++ b/src/hooks/useItems/useItems.js
@@ -8,6 +8,7 @@ import {
 
 import { initialItemsState } from './constants';
 import { identifyItems } from './helpers';
+import useCallbacksCallback from '~/hooks/useTableState/hooks/useCallbacksCallback';
 
 /**
  * This hook handles either just returning a provided array of items
@@ -27,6 +28,7 @@ const useItems = (
   externalItems,
   externalError,
   externalTotal,
+  { itemsOptions: { queryKey } = {} },
 ) => {
   const tableState = useRawTableState();
   const { filter, sort, pagination } = tableState || {};
@@ -49,8 +51,16 @@ const useItems = (
     data: { items: internalItems, total: internalTotal } = initialItemsState,
     isFetching: internalLoading,
     error: internalError,
+    refetch,
   } = useQuery({
-    queryKey: ['items', serialisedTableState, filter, sort, pagination],
+    queryKey: [
+      'items',
+      serialisedTableState,
+      filter,
+      sort,
+      pagination,
+      queryKey,
+    ],
     queryFn,
     enabled: useInternalState,
     refetchOnWindowFocus: false,
@@ -60,6 +70,8 @@ const useItems = (
   const total = useInternalState ? internalTotal : externalTotal;
   const error = useInternalState ? internalError : externalError;
   const loading = useInternalState ? internalLoading : externalLoading;
+
+  useCallbacksCallback('reload', refetch);
 
   return {
     loading,

--- a/src/hooks/useItems/useItems.stories.js
+++ b/src/hooks/useItems/useItems.stories.js
@@ -1,0 +1,178 @@
+import React, { useEffect, useCallback, useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Card, CardBody, Content } from '@patternfly/react-core';
+
+import defaultStoryMeta from '~/support/defaultStoryMeta';
+import columns from '~/support/factories/columns';
+
+import paginationSerialiser from '~/components/StaticTableToolsTable/helpers/serialisers/pagination';
+import sortSerialiser from '~/components/StaticTableToolsTable/helpers/serialisers/sort';
+import filtersSerialiser from '~/components/StaticTableToolsTable/helpers/serialisers/filters';
+import useExampleDataQuery from '~/support/hooks/useExampleDataQuery';
+import GenresDropdown from '~/support/components/GenresDropdown';
+
+import { TableToolsTable, TableStateProvider } from '~/components';
+import { useStateCallbacks } from '~/hooks';
+
+const queryClient = new QueryClient();
+
+const defaultOptions = {
+  debug: true,
+  serialisers: {
+    pagination: paginationSerialiser,
+    sort: sortSerialiser,
+    filters: filtersSerialiser,
+  },
+};
+
+const meta = {
+  title: 'useItems stories',
+  ...defaultStoryMeta,
+};
+
+const RefetchExample = () => {
+  const {
+    current: { reload },
+  } = useStateCallbacks();
+  const [selectedGenre, setSelectedGenre] = useState();
+  const { fetch } = useExampleDataQuery({
+    endpoint: '/api',
+    skip: true,
+  });
+
+  const fetchItems = useCallback(
+    async ({ pagination = {}, filters, sort } = {}) => {
+      const {
+        data: items,
+        meta: { total },
+      } = await fetch({
+        ...pagination,
+        ...(filters ? { filters } : {}),
+        ...(sort ? { sort } : {}),
+        ...(selectedGenre
+          ? { filters: `(.genre in ["${selectedGenre}"])` }
+          : {}),
+      });
+
+      return [items, total];
+    },
+    [fetch, selectedGenre],
+  );
+
+  const onSelectGenre = useCallback((genre) => {
+    setSelectedGenre(genre);
+  }, []);
+
+  useEffect(() => {
+    reload?.();
+  }, [selectedGenre, reload]);
+
+  return (
+    <>
+      <Content>
+        <p>
+          This story demonstrates calling the `reload` callback of the table,
+          after the `selectedGenre` has changed.
+        </p>
+      </Content>
+      <Card>
+        <CardBody>
+          <GenresDropdown selected={selectedGenre} onSelect={onSelectGenre} />
+        </CardBody>
+      </Card>
+      <TableToolsTable
+        items={fetchItems}
+        columns={columns}
+        options={{
+          ...defaultOptions,
+        }}
+      />
+    </>
+  );
+};
+
+export const RefetchStory = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TableStateProvider>
+          <Story />
+        </TableStateProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  render: (args) => <RefetchExample {...args} />,
+};
+
+const QueryKeyRefetchExample = () => {
+  const [selectedGenre, setSelectedGenre] = useState();
+  const { fetch } = useExampleDataQuery({
+    endpoint: '/api',
+    skip: true,
+  });
+
+  const fetchItems = useCallback(
+    async ({ pagination = {}, filters, sort } = {}) => {
+      const {
+        data: items,
+        meta: { total },
+      } = await fetch({
+        ...pagination,
+        ...(filters ? { filters } : {}),
+        ...(sort ? { sort } : {}),
+        ...(selectedGenre
+          ? { filters: `(.genre in ["${selectedGenre}"])` }
+          : {}),
+      });
+
+      return [items, total];
+    },
+    [fetch, selectedGenre],
+  );
+
+  const onSelectGenre = useCallback((genre) => {
+    setSelectedGenre(genre);
+  }, []);
+
+  return (
+    <>
+      <Content>
+        <p>
+          This story demonstrates reloading the table by providing a `queryKey`
+          for the `useItems` hook, which will append the provided `queryKey` to
+          the `queryKey` option passed to the (TanStack) `useQuery` hook.
+        </p>
+      </Content>
+      <Card>
+        <CardBody>
+          <GenresDropdown selected={selectedGenre} onSelect={onSelectGenre} />
+        </CardBody>
+      </Card>
+      <TableToolsTable
+        items={fetchItems}
+        columns={columns}
+        options={{
+          ...defaultOptions,
+          itemsOptions: {
+            queryKey: selectedGenre,
+          },
+        }}
+      />
+    </>
+  );
+};
+
+export const QueryKeyRefetchStory = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TableStateProvider>
+          <Story />
+        </TableStateProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  render: (args) => <QueryKeyRefetchExample {...args} />,
+};
+
+export default meta;

--- a/src/hooks/useTableTools/useTableTools.js
+++ b/src/hooks/useTableTools/useTableTools.js
@@ -53,6 +53,7 @@ const useTableTools = (
     externalItems,
     externalError,
     externalTotal,
+    options,
   );
   // TODO investigate and maybe refactor
   const actionResolverEnabled = items?.length > 0;

--- a/src/support/components/GenresDropdown.js
+++ b/src/support/components/GenresDropdown.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import propTypes from 'prop-types';
+
+import { FormSelect, FormSelectOption } from '@patternfly/react-core';
+
+import { genres } from '../factories/items';
+
+const GenresDropdown = ({ selected, onSelect: onSelectProp }) => {
+  const onSelect = (_event, value) => {
+    onSelectProp?.(value);
+  };
+
+  return (
+    <FormSelect
+      value={selected}
+      onChange={onSelect}
+      aria-label="FormSelect Input"
+      ouiaId="BasicFormSelect"
+    >
+      {genres.map((genre, index) => (
+        <FormSelectOption key={index} value={genre} label={genre} />
+      ))}
+    </FormSelect>
+  );
+};
+
+GenresDropdown.propTypes = {
+  selected: propTypes.array,
+  onSelect: propTypes.func,
+};
+
+export default GenresDropdown;


### PR DESCRIPTION
This adds a `setFilter` callback which allows setting a specific filter to a specific value.

It adds a `reload` callback that can be access via the context and
can be called explicitly to reload the table.

It also enables passing a `queryKey` to be appended to the `queryKey` used
for the internal `useQuery` hook.
