### PR TITLE
fix(useTableSort): Use deep compare memo for state options

### DIFF
--- a/src/components/TableToolsTable/TableToolsTableExperiments.stories.js
+++ b/src/components/TableToolsTable/TableToolsTableExperiments.stories.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import propTypes from 'prop-types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
@@ -233,6 +233,52 @@ export const AllEmptyStory = {
     ),
   ],
   render: (args) => <AllEmptyExample {...args} />,
+};
+
+const CyclicColumnsIssueExample = () => {
+  const {
+    loading,
+    result: { data, meta: { total } = {} } = {},
+    error,
+  } = useExampleDataQuery({
+    endpoint: '/api',
+    useTableState: true,
+  });
+
+  const dynamicColumn = useMemo(() => {
+    return {
+      ...columns[0],
+      title: (
+        <>
+          <strong>Yolo</strong>
+        </>
+      ),
+    };
+  }, []);
+
+  return (
+    <TableToolsTable
+      loading={loading}
+      items={data}
+      error={error}
+      total={total}
+      columns={[dynamicColumn, ...columns.slice(1)]}
+      options={defaultOptions}
+    />
+  );
+};
+
+export const CyclicColumnsIssueStory = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TableStateProvider>
+          <Story />
+        </TableStateProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  render: (args) => <CyclicColumnsIssueExample {...args} />,
 };
 
 export default meta;

--- a/src/hooks/useTableSort/useTableSort.js
+++ b/src/hooks/useTableSort/useTableSort.js
@@ -1,4 +1,5 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
+import { useDeepCompareMemo } from 'use-deep-compare';
 
 import useTableState, { useRawTableState } from '~/hooks/useTableState';
 
@@ -35,25 +36,24 @@ import { TABLE_STATE_NAMESPACE } from './constants';
  *
  */
 const useTableSort = (columns, options = {}) => {
-  const { sortBy: initialSortBy, serialisers, onSort: onSortOption } = options;
-  const serialiser = useCallback(
-    (state) => options.serialisers.sort(state, columns),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(columns), JSON.stringify(options.serialisers)],
-  );
+  const {
+    sortBy: initialSortBy,
+    serialisers: { sort: serialiser } = {},
+    onSort: onSortOption,
+  } = options;
 
   const { tableView } = useRawTableState() || {};
   const offset = columnOffset({ ...options, tableView });
 
-  const stateOptions = useMemo(
+  const stateOptions = useDeepCompareMemo(
     () => ({
-      ...(serialisers?.sort
+      ...(serialiser
         ? {
-            serialiser,
+            serialiser: (state) => serialiser(state, columns),
           }
         : {}),
     }),
-    [serialisers, serialiser],
+    [serialiser, columns],
   );
   const [sortBy, setSortBy] = useTableState(
     TABLE_STATE_NAMESPACE,

--- a/src/support/factories/columns.js
+++ b/src/support/factories/columns.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
+import { fitContent, nowrap } from '@patternfly/react-table';
 import { Label } from '@patternfly/react-core';
 
 const Title = ({ title }) => <strong>{title}</strong>;
@@ -32,13 +33,19 @@ export const genre = {
   Component: Genre,
   renderExport: ({ genre }) => genre,
   sortable: 'genre',
+  transforms: [fitContent],
 };
 
 export const releaseYear = {
-  title: 'Released',
+  title: (
+    <>
+      Released <span style={{ color: 'grey' }}>(year)</span>
+    </>
+  ),
   Component: ({ releaseYear }) => releaseYear,
   renderExport: ({ releaseYear }) => releaseYear,
   sortable: 'releaseYear',
+  transforms: [nowrap],
 };
 
 export const rating = {


### PR DESCRIPTION
This PR fixes an issue with columns that have a React element as a title. This causes `JSON.stringify` to fail with a "cyclic object" error. 

To remedy this the PR refactors the table sort hook to use the deep compare hooks for memoising. 

The "CyclicColumnsIssueExample" illustrates the issue.

**How to test:**

1) Run `npm install && npm run storybook`
2) Open the CyclicColumnsIssueExample story.
3) Verify all still works even with the "dynamicColumn"
(4) Optionally revert the changes to the sort hook to see the actual issue)
