### PR TITLE
fix(useColumnManager): Filter manageable columns better

### DIFF
--- a/src/hooks/useColumnManager/helper.js
+++ b/src/hooks/useColumnManager/helper.js
@@ -1,14 +1,22 @@
 export const getColumnsForModal = (columns = [], selectedColumns) =>
-  columns.map(({ title, manageable, isShown: isShownProp }) => {
-    const isShown = selectedColumns?.includes(title) || isShownProp;
-    const isUntoggleable =
-      typeof manageable !== 'undefined' ? !manageable : false;
+  columns
+    .map(({ title, manageable, isShown: isShownProp }) => {
+      const isShown = selectedColumns?.includes(title) || isShownProp;
+      const isUntoggleable =
+        typeof manageable !== 'undefined' ? !manageable : false;
 
-    return {
-      title,
-      key: title,
-      isUntoggleable,
-      isShownByDefault: isShown,
-      isShown,
-    };
-  });
+      return {
+        title,
+        key: title,
+        isUntoggleable,
+        isShownByDefault: isShown,
+        isShown,
+      };
+    })
+    .filter(({ isUntoggleable }) => !isUntoggleable)
+    .map((column, idx) => ({
+      ...column,
+      // TODO this is a workaround to prevent users from deselecting all columns and see an empty table
+      // However, this should actually be handled directly within the Column management modal in the pf component groups component
+      isUntoggleable: idx === 0,
+    }));

--- a/src/support/factories/columns.js
+++ b/src/support/factories/columns.js
@@ -18,7 +18,6 @@ export const title = {
   Component: Title,
   renderExport: ({ title }) => title,
   sortable: 'title',
-  manageable: false,
 };
 
 export const artist = {
@@ -58,6 +57,7 @@ export const rating = {
       .join(''),
   renderExport: ({ rating }) => rating,
   sortable: 'rating',
+  manageable: false,
 };
 
 export default [title, artist, releaseYear, genre, rating];


### PR DESCRIPTION
This PR changes what `manageable` means a little bit. It will filter out columns that have `manageable` set to `false`. 

It will also make the first column "untoggleable" by default to prevent user from deselecting all columns and see an a table without columns.

**Before:**

<img width="558" height="400" alt="Screenshot 2025-09-05 at 11 55 00" src="https://github.com/user-attachments/assets/62268059-0099-40b8-bffb-25c66dfe149f" />


**After:**

<img width="563" height="364" alt="Screenshot 2025-09-05 at 11 54 35" src="https://github.com/user-attachments/assets/5f7c7f53-cfb9-4ae2-98f3-0ffef5265668" />


## How to test

1) Run `npm install && npm run storybook` & open any of the examples with column management enabled
2) Verify that manageable columns are filtered out.
3) Verify that the first is untoggleable. 
