### PR TITLE
feat(useQueryWithUtilities): Return useQuery refetch function

### DIFF
--- a/src/utilities/hooks/useQueryWithUtilities/useQueryWithUtilities.js
+++ b/src/utilities/hooks/useQueryWithUtilities/useQueryWithUtilities.js
@@ -48,6 +48,7 @@ const useQueryWithUtilities = ({
     isFetching: queryLoading,
     data: queryResult,
     error: queryError,
+    refetch,
   } = useQuery({
     queryKey,
     queryFn: async () => await queryFn(),
@@ -118,6 +119,7 @@ const useQueryWithUtilities = ({
     loading,
     result,
     error,
+    refetch,
     query,
     queryTotalBatched,
     ...tableQueries,

--- a/src/utilities/hooks/useQueryWithUtilities/useQueryWithUtilities.stories.js
+++ b/src/utilities/hooks/useQueryWithUtilities/useQueryWithUtilities.stories.js
@@ -6,6 +6,8 @@ import {
   Content,
   Spinner,
   Bullseye,
+  Button,
+  Flex,
   Tabs,
   Tab,
   TabTitleText,
@@ -13,6 +15,7 @@ import {
   ListItem,
 } from '@patternfly/react-core';
 import axios from 'axios';
+import { faker } from '@faker-js/faker';
 
 import defaultStoryMeta from '~/support/defaultStoryMeta';
 import columns from '~/support/factories/columns';
@@ -405,4 +408,54 @@ export const TableQueriesWithCombinedFiltersStory = {
     ),
   ],
   render: (args) => <TableQueriesWithCombinedFiltersExample {...args} />,
+};
+
+const QueryRefetchExample = () => {
+  const fetchFn = useCallback(
+    async (params) => await restApi('/api', params),
+    [],
+  );
+
+  const { loading, refetch, query } = useQueryWithUtilities({
+    fetchFn,
+    params: {
+      limit: 1,
+    },
+  });
+  const onDataRefetch = async () => {
+    refetch();
+  };
+  const onDataFetch = async () => {
+    query();
+  };
+
+  return (
+    <>
+      <Flex columnGap={{ default: 'columnGapSm' }}>
+        <Content component="h4">Random text:</Content>
+        {loading ? (
+          <Spinner size="md" />
+        ) : (
+          <Content>{faker.commerce.productName()}</Content>
+        )}
+      </Flex>
+      <Flex columnGap={{ default: 'columnGapSm' }}>
+        <Button onClick={onDataRefetch}>Refetch data</Button>
+        <Button onClick={onDataFetch}>Fetch data</Button>
+      </Flex>
+    </>
+  );
+};
+
+export const QueryRefetchStory = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TableStateProvider>
+          <Story />
+        </TableStateProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  render: (args) => <QueryRefetchExample {...args} />,
 };


### PR DESCRIPTION
This adds `refetch` function to `useQueryWithUtilities` return so it can be used on refetching items when component re-render is needed

How to test:

1. Run Story book
2. Open QueryRefetchExample story
3. Check if Fetch data button calls API but components stays the same
4. Check if Refetch data button calls API and also re-renders component