### PR TITLE
fix(useBulkSelect): Respect itemId on page selection

### DIFF
--- a/src/components/TableToolsTable/TableToolsTableExperiments.stories.js
+++ b/src/components/TableToolsTable/TableToolsTableExperiments.stories.js
@@ -207,6 +207,107 @@ export const BulkSelectStory = {
   render: (args) => <BulkSelectExample {...args} />,
 };
 
+const BulkSelectWithItemIdExample = () => {
+  const [totalItems, setTotal] = useState(101);
+
+  const {
+    loading,
+    result: { data, meta: { total } = {} } = {},
+    error,
+    itemIdsInTable,
+  } = useExampleDataQuery({
+    endpoint: '/api',
+    useTableState: true,
+    params: {
+      total: totalItems,
+    },
+  });
+
+  const itemsWithOnlyItemId = useMemo(
+    () =>
+      data?.map(({ id, ...rest }) => ({
+        ...rest,
+        itemId: id,
+      })),
+    [data],
+  );
+
+  const {
+    current: { resetSelection, setSelection },
+  } = useStateCallbacks();
+  const fullTableState = useFullTableState() || {};
+
+  const onSelect = useCallback((selection) => {
+    console.log('Current Selection with itemId', selection);
+  }, []);
+
+  return (
+    <>
+      <Card>
+        <CardBody>
+          <Slider
+            value={totalItems}
+            max={2048}
+            onChange={(_event, value) => setTotal(value)}
+          />
+        </CardBody>
+      </Card>
+      <Card>
+        <CardBody>
+          <Button
+            variant="primary"
+            ouiaId="Primary"
+            onClick={() => resetSelection()}
+          >
+            Reset Selection
+          </Button>
+          <Button
+            variant="primary"
+            ouiaId="Primary"
+            onClick={() =>
+              setSelection(itemsWithOnlyItemId?.map(({ itemId }) => itemId))
+            }
+          >
+            Select only page
+          </Button>
+          <Label>
+            Selected items in context:{' '}
+            {fullTableState?.tableState?.selected?.length}
+          </Label>
+        </CardBody>
+      </Card>
+      <br />
+      <TableToolsTable
+        loading={loading}
+        items={itemsWithOnlyItemId}
+        total={total}
+        error={error}
+        columns={columns}
+        options={{
+          ...defaultOptions,
+          debug: true,
+          onSelect,
+          itemIdsInTable,
+          identifier: 'itemId',
+        }}
+      />
+    </>
+  );
+};
+
+export const BulkSelectWithItemIdStory = {
+  decorators: [
+    (Story) => (
+      <QueryClientProvider client={queryClient}>
+        <TableStateProvider>
+          <Story />
+        </TableStateProvider>
+      </QueryClientProvider>
+    ),
+  ],
+  render: (args) => <BulkSelectWithItemIdExample {...args} />,
+};
+
 const AllEmptyExample = () => {
   const { loading } = useExampleDataQuery({
     endpoint: '/api',

--- a/src/hooks/useTableTools/useTableTools.js
+++ b/src/hooks/useTableTools/useTableTools.js
@@ -84,6 +84,7 @@ const useTableTools = (
     total: items?.length || 0,
   });
 
+  const identifier = options.identifier || 'itemId';
   const {
     toolbarProps: bulkSelectToolbarProps,
     tableProps: bulkSelectTableProps,
@@ -91,7 +92,7 @@ const useTableTools = (
   } = useBulkSelect({
     ...options,
     total,
-    itemIdsOnPage: items?.map(({ id }) => id),
+    itemIdsOnPage: items?.map((item) => item[identifier]),
   });
 
   const {


### PR DESCRIPTION
Unifies behaviour when itemId is used for bulk select. [Currently 1by1 item selection will work](https://github.com/bastilian/tabletools/blob/main/src/hooks/useBulkSelect/useBulkSelect.js#L52) but selection page will not if id and itemId are not matching. So we need to unify behaviour for page selection too and use itemId if no identifier provided

Story point added shows the issue if old implementation is returned