### PR TITLE
feat(RHINENG-22169): Add enableDragDrop option for columnManager

### DIFF
--- a/src/hooks/useColumnManager/useColumnManager.js
+++ b/src/hooks/useColumnManager/useColumnManager.js
@@ -27,6 +27,7 @@ const useColumnManager = (options = {}) => {
     columns,
     manageColumns: enableColumnManager,
     manageColumnLabel = 'Manage columns',
+    enableDragDrop,
   } = options;
 
   const [selectedColumns, setSelectedColumns] = useState(
@@ -77,6 +78,7 @@ const useColumnManager = (options = {}) => {
           isOpen: isManagerOpen,
           onClose,
           applyColumns: applyColumns,
+          enableDragDrop,
         },
       }
     : { columns };


### PR DESCRIPTION
This PR adds the enableDragDrop property for the ColumnManagementModal. I tried to test this prop in a storybook, but it did work. I'm wanting to get this option here and then test it against inventory by passing the option.