### PR TITLE
fix(ToggleColor): correct colors for toggle icons

### DIFF
--- a/src/components/TableViewToggle.js
+++ b/src/components/TableViewToggle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import propTypes from 'prop-types';
-import { ToggleGroup, ToggleGroupItem, Icon } from '@patternfly/react-core';
+import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core';
 
 /**
  * Component used when more than 1 view type is available for a table
@@ -15,11 +15,7 @@ const TableViewToggle = ({ views, onToggle, currentTableView }) => (
     {Object.entries(views).map(([key, { icon: ToggleIcon }]) => (
       <ToggleGroupItem
         key={key}
-        icon={
-          <Icon>
-            <ToggleIcon />
-          </Icon>
-        }
+        icon={<ToggleIcon />}
         aria-label={key}
         isSelected={currentTableView === key}
         onChange={() => onToggle(key)}


### PR DESCRIPTION
Seems we don't need to wrap switch icons into <Icon> as it applies it's own color scheme. 

https://redhat.atlassian.net/browse/RHINENG-24054


Before:
<img width="963" height="349" alt="image" src="https://github.com/user-attachments/assets/fb4cf34e-60f3-448f-9441-faa304251654" />

After:
<img width="1465" height="702" alt="image" src="https://github.com/user-attachments/assets/be59b2e8-e077-449f-b267-76db6c1da9d5" />
