### PR TITLE
feat(useFilterConfig): Implement "Reset filters"

### DIFF
--- a/src/hooks/useFilterConfig/hooks/useEventHandlers.js
+++ b/src/hooks/useFilterConfig/hooks/useEventHandlers.js
@@ -8,7 +8,7 @@ const useEventHandlers = ({
   activeFilters,
   onFilterUpdate: onFilterUpdateCallback,
   onDeleteFilter,
-  resetOnClear,
+  useReset,
   filterTypes,
   selectionActions: { select, deselect, reset, clear },
 }) => {
@@ -36,7 +36,7 @@ const useEventHandlers = ({
   const onFilterDelete = useCallback(
     async (_event, chips, clearAll = false) => {
       if (clearAll) {
-        if (resetOnClear) {
+        if (useReset) {
           reset();
         } else {
           clear();
@@ -60,7 +60,7 @@ const useEventHandlers = ({
       reset,
       clear,
       deselect,
-      resetOnClear,
+      useReset,
       filterTypes,
     ],
   );

--- a/src/hooks/useFilterConfig/hooks/useFilterOptions.js
+++ b/src/hooks/useFilterConfig/hooks/useFilterOptions.js
@@ -11,6 +11,7 @@ const useFilterOptions = (options) => {
     filterConfig: staticFilterConfig = [],
     activeFilters: initialActiveFilters,
     customFilterTypes,
+    useReset,
   } = filters || {};
   const filterConfig = useResolvedProps(staticFilterConfig, [
     'items',
@@ -31,6 +32,7 @@ const useFilterOptions = (options) => {
       },
       initialActiveFilters,
       serialisers,
+      useReset,
     }),
     [
       enableFilters,
@@ -39,6 +41,7 @@ const useFilterOptions = (options) => {
       customFilterTypes,
       initialActiveFilters,
       serialisers,
+      useReset,
     ],
   );
 

--- a/src/hooks/useFilterConfig/useFilterConfig.js
+++ b/src/hooks/useFilterConfig/useFilterConfig.js
@@ -41,18 +41,21 @@ const useFilterConfig = (options) => {
     serialisers,
     enableFilters,
     filterTypes,
+    useReset,
   } = useFilterOptions(options);
 
-  const { selection: activeFilters, ...selectionActions } = useSelectionManager(
-    initialActiveFilters,
-    { withGroups: true },
-  );
+  const {
+    selection: activeFilters,
+    isInitialSelection,
+    ...selectionActions
+  } = useSelectionManager(initialActiveFilters, { withGroups: true });
   const { onFilterUpdate, onFilterDelete } = useEventHandlers({
     ...options,
     filterConfig,
     activeFilters,
     selectionActions,
     filterTypes,
+    useReset,
   });
 
   const { isFilterModalOpen, openFilterModal, filterModalProps } =
@@ -94,6 +97,7 @@ const useFilterConfig = (options) => {
     [selectionActions],
   );
 
+  useCallbacksCallback('resetFilters', selectionActions.rest);
   useCallbacksCallback('clearFilters', selectionActions.clear);
   useCallbacksCallback('setFilter', setFilter);
 
@@ -102,6 +106,12 @@ const useFilterConfig = (options) => {
         toolbarProps: {
           filterConfig: builtFilterConfig,
           activeFiltersConfig: {
+            ...(useReset
+              ? {
+                  deleteTitle: 'Reset filters',
+                  showDeleteButton: isInitialSelection ? false : true,
+                }
+              : {}),
             filters: toFilterChips(filterConfig, filterTypes, activeFilters),
             onDelete: onFilterDelete,
           },

--- a/src/hooks/useFilterConfig/useFilterConfig.stories.js
+++ b/src/hooks/useFilterConfig/useFilterConfig.stories.js
@@ -251,6 +251,7 @@ const FilterChipsWithIconsExample = () => {
           activeFilters: {
             raiting: ['cool', 'not-sure'],
           },
+          useReset: true,
         }}
         options={{
           ...defaultOptions,

--- a/src/hooks/useSelectionManager/reducer.js
+++ b/src/hooks/useSelectionManager/reducer.js
@@ -1,5 +1,6 @@
 import isObject from 'lodash/isObject';
 import uniq from 'lodash/uniq';
+// TODO this reducer should be refactored at some point
 
 const DEFAULT_GROUP_KEY = 'default';
 const selectionGroup = (action) => action.group || DEFAULT_GROUP_KEY;
@@ -72,8 +73,23 @@ const toggle = (state, action) => {
     : select(state, action);
 };
 
-const reset = (state, action) =>
-  init(!state.hasOwnProperty(DEFAULT_GROUP_KEY))(action?.preselected); // eslint-disable-line
+const reset = (state, action) => {
+  if (action.withGroups) {
+    return {
+      ...(action.group
+        ? {
+            ...state,
+            [action.group]: action.initialSelection,
+          }
+        : action.initialSelection || {}),
+    };
+  } else {
+    return {
+      default: action.initialSelection,
+    };
+  }
+};
+
 const clear = (state) => init(!state.hasOwnProperty(DEFAULT_GROUP_KEY))(); // eslint-disable-line
 
 export default (state, action) =>

--- a/src/hooks/useSelectionManager/useSelectionManager.js
+++ b/src/hooks/useSelectionManager/useSelectionManager.js
@@ -1,4 +1,5 @@
 import { useCallback, useReducer, useRef } from 'react';
+import { useDeepCompareMemo } from 'use-deep-compare';
 
 import reducer, { init as initReducer } from './reducer';
 
@@ -19,6 +20,11 @@ const useSelectionManager = (selected, { withGroups = false } = {}) => {
     reducer,
     selected,
     initReducer(withGroups),
+  );
+  const isInitialSelection = useDeepCompareMemo(
+    () =>
+      JSON.stringify(initialSelection.current) === JSON.stringify(selection),
+    [initialSelection, selection],
   );
 
   const set = useCallback(
@@ -45,9 +51,15 @@ const useSelectionManager = (selected, { withGroups = false } = {}) => {
 
   const reset = useCallback(
     (group) => {
-      set(initialSelection.current, group);
+      dispatch({
+        type: 'reset',
+        withGroups,
+        ...(group
+          ? { group, initialSelection: initialSelection.current[group] }
+          : { initialSelection: initialSelection.current }),
+      });
     },
-    [set, initialSelection],
+    [initialSelection, withGroups],
   );
 
   const clear = useCallback((group) => set(undefined, group), [set]);
@@ -60,6 +72,7 @@ const useSelectionManager = (selected, { withGroups = false } = {}) => {
     reset,
     clear,
     selection: withGroups ? selection : selection.default,
+    isInitialSelection,
   };
 };
 

--- a/src/hooks/useSelectionManager/useSelectionManager.test.js
+++ b/src/hooks/useSelectionManager/useSelectionManager.test.js
@@ -13,7 +13,8 @@ describe('useSelectionManager', () => {
   });
 
   describe('withGroups: false', () => {
-    const defaultArguments = [[1, 2, 3, 4]];
+    const selection = [1, 2, 3, 4];
+    const defaultArguments = [selection];
 
     it('returns an object with function to manage selections wihtout groups', () => {
       const { result } = renderHook(() =>
@@ -80,10 +81,8 @@ describe('useSelectionManager', () => {
   });
 
   describe('withGroups true', () => {
-    const defaultArguments = [
-      { group1: [1, 2, 3, 4], group2: [12, 23, 34, 45] },
-      { withGroups: true },
-    ];
+    const initialSelection = { group1: [1, 2, 3, 4], group2: [12, 23, 34, 45] };
+    const defaultArguments = [initialSelection, { withGroups: true }];
 
     it('returns an object with function to manage selections with groups', () => {
       const { result } = renderHook(() =>
@@ -105,10 +104,10 @@ describe('useSelectionManager', () => {
         result.current.select(42, 'group2');
       });
 
-      expect(result.current.selection.group2).toEqual([
-        42,
-        ...defaultArguments[0].group2,
-      ]);
+      expect(result.current.selection).toEqual({
+        ...initialSelection,
+        group2: [42, ...initialSelection.group2],
+      });
     });
 
     it('removes an item from the selection when calling deselect', () => {
@@ -120,31 +119,73 @@ describe('useSelectionManager', () => {
         result.current.deselect(2, 'group1');
       });
 
-      expect(result.current.selection.group1).toEqual([1, 3, 4]);
+      expect(result.current.selection).toEqual({
+        ...initialSelection,
+        group1: [1, 3, 4],
+      });
     });
 
     it('sets items for a selection when calling set', () => {
       const { result } = renderHook(() =>
         useSelectionManager(...defaultArguments),
       );
+      const newSelection = [0, 9, 8, 45, 3];
 
       act(() => {
-        result.current.set([0, 9, 8, 45, 3], 'group1');
+        result.current.set(newSelection, 'group1');
       });
 
-      expect(result.current.selection.group1).toEqual([0, 9, 8, 45, 3]);
+      expect(result.current.selection).toEqual({
+        ...initialSelection,
+        group1: newSelection,
+      });
     });
 
     it('resets selection to initially passed in selected on reset', () => {
       const { result } = renderHook(() =>
         useSelectionManager(...defaultArguments),
       );
+      const newSelection = [1, 2, 3];
 
       act(() => {
-        result.current.set([0, 9, 8, 45, 3], 'group1');
+        result.current.set(newSelection, 'group1');
       });
 
-      expect(result.current.selection.group1).toEqual([0, 9, 8, 45, 3]);
+      expect(result.current.selection).toEqual({
+        ...initialSelection,
+        group1: newSelection,
+      });
+
+      act(() => {
+        result.current.reset('group1');
+      });
+
+      expect(result.current.selection).toEqual(initialSelection);
+    });
+
+    it('resets selection of all groups if no specific group is set', () => {
+      const { result } = renderHook(() =>
+        useSelectionManager(...defaultArguments),
+      );
+      const newSelection = [1, 2, 3];
+
+      act(() => {
+        result.current.set(newSelection, 'group1');
+        result.current.set(newSelection, 'group2');
+        result.current.set(newSelection, 'group3');
+      });
+
+      expect(result.current.selection).toEqual({
+        group1: newSelection,
+        group2: newSelection,
+        group3: newSelection,
+      });
+
+      act(() => {
+        result.current.reset();
+      });
+
+      expect(result.current.selection).toEqual(initialSelection);
     });
   });
 });


### PR DESCRIPTION
This fixes the reset in the selection manager and exposes a "Reset filters" feature that can be enabled by setting `useReset` to `true` in the options passed to a TableToolsTable.

It also adds some more tests and a story to verify the correct behaviour.



https://github.com/user-attachments/assets/1088dd6d-b807-4145-830f-c932fc90bf84

