### PR TITLE
Allow full width row details content

### DIFF
--- a/src/components/TableToolsTable/TableToolsTable.stories.js
+++ b/src/components/TableToolsTable/TableToolsTable.stories.js
@@ -202,6 +202,7 @@ const CommonExample = ({
             }
           : {}),
         ...(enableSimpleBulkSelect ? { onSelect: true } : {}),
+        detailsProps: { fullWidth: true },
       }}
     />
   );

--- a/src/hooks/useExpandable/helpers.js
+++ b/src/hooks/useExpandable/helpers.js
@@ -1,7 +1,29 @@
 import React from 'react';
 
-const detailsRowForRule = (item, DetailsComponent, colSpan, runningIndex) => ({
+const detailsRowColSpan = (options = {}) => {
+  const baseColumns = options.columns?.length || 0;
+
+  const hasExpandableControlColumn =
+    !!options.detailsComponent || !!options.treeTable;
+  const hasSelectableControlColumn =
+    !!options.onRadioSelect || !!options.onSelect;
+
+  return (
+    baseColumns +
+    (hasExpandableControlColumn ? 1 : 0) +
+    (hasSelectableControlColumn ? 1 : 0)
+  );
+};
+
+const detailsRowForRule = (
+  item,
+  DetailsComponent,
+  colSpan,
+  runningIndex,
+  detailsProps = {},
+) => ({
   parent: runningIndex() - 1,
+  ...detailsProps,
   props: {
     ...item.props,
     'aria-setsize': 0,
@@ -23,8 +45,9 @@ export const itemDetailsRow = (item, options, runningIndex) =>
   detailsRowForRule(
     item,
     options.detailsComponent,
-    options.columns?.length,
+    detailsRowColSpan(options),
     runningIndex,
+    options?.detailsProps || {},
   );
 
 const expandTreeTableRow = (firstRow, isOpen) => ({

--- a/src/hooks/useExpandable/useExpandable.js
+++ b/src/hooks/useExpandable/useExpandable.js
@@ -18,6 +18,7 @@ import { itemDetailsRow, addExpandProp } from './helpers';
  *
  *  @param   {object}              [options]                  AsyncTableTools options
  *  @param   {object}              [options.detailsComponent] A component that should be rendered as a details row
+ *  @param   {object}              [options.detailsProps]     Props spread onto each details row
  *
  *  @returns {useExpandableReturn}                            An object of props meant to be used in the {@link TableToolsTable}
  *

--- a/src/hooks/useExpandable/useExpandable.test.js
+++ b/src/hooks/useExpandable/useExpandable.test.js
@@ -67,6 +67,7 @@ describe('useExpandable', () => {
             title: expect.anything(), //non-rendered ExampleDetailsRow
             props: {
               className: 'compliance-rule-details',
+              colSpan: 1,
             },
           },
         ],
@@ -101,5 +102,85 @@ describe('useExpandable', () => {
     });
 
     expect(result.current.tableView.isItemOpen('test-id')).toBe(false);
+  });
+
+  it('includes control columns in details row colSpan', () => {
+    const { result } = renderHook(
+      () =>
+        useExpandable({
+          detailsComponent: ExampleDetailsRow,
+          columns: [{ title: 'Name' }, { title: 'OS version' }],
+          onRadioSelect: jest.fn(),
+        }),
+      DEFAULT_RENDER_OPTIONS,
+    );
+
+    act(() => {
+      result.current.tableProps.onCollapse(null, 0, true, {
+        item: { itemId: 'test-id' },
+      });
+    });
+
+    const openedRow = result.current.tableView.expandRow(
+      row,
+      [],
+      () => 1,
+      false,
+    );
+
+    expect(openedRow[1].cells[0].props.colSpan).toEqual(4);
+  });
+
+  it('marks details rows as fullWidth when configured', () => {
+    const { result } = renderHook(
+      () =>
+        useExpandable({
+          detailsComponent: ExampleDetailsRow,
+          columns: [{ title: 'Name' }, { title: 'OS version' }],
+          detailsProps: { fullWidth: true },
+        }),
+      DEFAULT_RENDER_OPTIONS,
+    );
+
+    act(() => {
+      result.current.tableProps.onCollapse(null, 0, true, {
+        item: { itemId: 'test-id' },
+      });
+    });
+
+    const openedRow = result.current.tableView.expandRow(
+      row,
+      [],
+      () => 1,
+      false,
+    );
+
+    expect(openedRow[1].fullWidth).toBe(true);
+  });
+
+  it('does not mark details rows as fullWidth by default', () => {
+    const { result } = renderHook(
+      () =>
+        useExpandable({
+          detailsComponent: ExampleDetailsRow,
+          columns: [{ title: 'Name' }, { title: 'OS version' }],
+        }),
+      DEFAULT_RENDER_OPTIONS,
+    );
+
+    act(() => {
+      result.current.tableProps.onCollapse(null, 0, true, {
+        item: { itemId: 'test-id' },
+      });
+    });
+
+    const openedRow = result.current.tableView.expandRow(
+      row,
+      [],
+      () => 1,
+      false,
+    );
+
+    expect(openedRow[1].fullWidth).toBeUndefined();
   });
 });

--- a/src/support/components/DetailsRow.js
+++ b/src/support/components/DetailsRow.js
@@ -5,8 +5,7 @@ import { Content, ContentVariants } from '@patternfly/react-core';
 const DetailsRow = ({ item: { description } }) => (
   <Content
     component={ContentVariants.p}
-    style={{ background: 'white' }}
-    className="pf-v5-u-p-xl"
+    style={{ background: 'white', padding: 'var(--pf-t--global--spacer--lg)' }}
   >
     {description}
   </Content>


### PR DESCRIPTION
Allow passing fullWidth prop to be able to show row details content on full width.
Updated storybook too:
<img width="1370" height="717" alt="Screenshot 2026-05-28 at 12 12 07" src="https://github.com/user-attachments/assets/f9c85624-089e-4503-b075-b9ff2fc8f2e8" />


Before:
<img width="1793" height="1213" alt="image" src="https://github.com/user-attachments/assets/4fddaa96-5b88-4dad-a1ef-335867ed9cab" />


After:
<img width="1731" height="1195" alt="image" src="https://github.com/user-attachments/assets/8268c2c9-ca23-4e6a-87ef-40763dc0ba97" />
