### PR TITLE
fix(useExpandable): avoid showing checkbox on item details

### DIFF
--- a/src/hooks/useExpandable/helpers.js
+++ b/src/hooks/useExpandable/helpers.js
@@ -2,10 +2,14 @@ import React from 'react';
 
 const detailsRowForRule = (item, DetailsComponent, colSpan, runningIndex) => ({
   parent: runningIndex() - 1,
-  props: {
-    ...item.props,
-    'aria-setsize': 0,
-  },
+  props: (() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { 'aria-level': _ariaLevel, ...detailsRowProps } = item.props || {};
+    return {
+      ...detailsRowProps,
+      'aria-setsize': 0,
+    };
+  })(),
   cells: [
     {
       title: <DetailsComponent item={item} key={'item-' + item.rowId} />,


### PR DESCRIPTION
Before: 
<img width="1683" height="864" alt="image" src="https://github.com/user-attachments/assets/f766a663-1e24-402b-a8ca-b5deaf7e5015" />


After:

<img width="1881" height="1015" alt="image" src="https://github.com/user-attachments/assets/273c33d2-9334-47db-8c74-a01bcc85b209" />
